### PR TITLE
Make example working

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,27 +71,13 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-      </exclusions>
+      <scope>provided</scope>
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-      </exclusions>
+      <scope>provided</scope>
       <version>${jackson.version}</version>
     </dependency>
   </dependencies>

--- a/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -6,7 +6,7 @@
             <subsystem name="jaxrs"/>
         </exclude-subsystems>
         <dependencies>
-            <module name="com.fasterxml.jackson.core.jackson-databind" />
+            <module name="com.fasterxml.jackson.core.jackson-databind" slot="2.12.1" />
 <!--            <module name="com.fasterxml.jackson.core.jackson-annotations"  services="import" />-->
             <module name="com.fasterxml.jackson.datatype.jackson-datatype-joda" slot="2.12.1" />
             <module name="com.fasterxml.jackson.datatype.jackson-datatype-jsr310" slot="2.12.1" />


### PR DESCRIPTION
* Adjusts scopes of Jackson dependencies from `compile` to `provided`
* Define slot for `jackson-databind` module dependency